### PR TITLE
Add initial Flask webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ If you are interested in any aspect of this project, feel free to message me on 
    jupyter notebook
    ```
    Then open `old_testament/genesis/Genesis.ipynb`.
+4. Run the web application:
+   ```bash
+   flask --app webapp run
+   ```
 
 The notebook imports helpers from the `bible` package to model passages programmatically.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "MIT"}
 dependencies = []
 
 [project.optional-dependencies]
-develop = ["pytest", "jupyter", "flake8", "black", "nbqa"]
+develop = ["pytest", "jupyter", "flake8", "black", "nbqa", "flask"]
 
 # TODO: review package metadata before release
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ jupyter>=1.0
 flake8>=6.0
 black>=24.3
 nbqa>=1.7
+flask>=2.2
 # TODO: lock versions for reproducible environment
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,9 @@
+from webapp import create_app
+
+
+def test_index_route():
+    app = create_app()
+    client = app.test_client()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Welcome to the Holy Bible App" in response.data

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,0 +1,15 @@
+from flask import Flask, render_template
+from bible.actions import TheActionsOfGod
+
+
+def create_app():
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index():
+        # Using the actions module to demonstrate dynamic content
+        verse = TheActionsOfGod.said("Let there be light")
+        return render_template("index.html", verse=verse)
+
+    return app

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Holy Bible App</title>
+  </head>
+  <body>
+    <h1>Welcome to the Holy Bible App</h1>
+    <p>{{ verse }} was spoken in Genesis.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask application and HTML template
- document running the web app
- allow `flask` in optional dependencies
- add `flask` to requirements
- test the new web route

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$(pwd) pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846d267eff4832f821d18bcb02f3394