### PR TITLE
Add basic logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,12 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on setting up your 
 - Define `PHYSICS` and `INFORMATION` classes per `Blueprints.txt`.
 - Add more unit tests to improve coverage.
 - Polish documentation for a public launch.
+
+## Logging
+The helper functions in ``bible.actions`` emit logs using Python's ``logging``
+module. Control the verbosity with the ``BIBLE_LOG_LEVEL`` environment variable.
+For example:
+
+```bash
+export BIBLE_LOG_LEVEL=DEBUG
+```

--- a/bible/__init__.py
+++ b/bible/__init__.py
@@ -1,0 +1,24 @@
+"""Bible package configuration and shared utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+
+def _configure_logging() -> None:
+    """Configure basic logging for the package.
+
+    The log level can be controlled with the ``BIBLE_LOG_LEVEL`` environment
+    variable. By default ``INFO`` messages and above are shown.
+    """
+
+    level_name = os.getenv("BIBLE_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+_configure_logging()

--- a/bible/actions.py
+++ b/bible/actions.py
@@ -1,3 +1,9 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
 class TheActionsOfGod:
     """A minimal implementation of actions used in Genesis."""
 
@@ -5,42 +11,54 @@ class TheActionsOfGod:
 
     @staticmethod
     def heavens():
+        logger.info("Creating the heavens")
         return "heavens"
 
     @staticmethod
     def planet(name="earth"):
+        logger.info("Creating planet %s", name)
         return {"name": name}
 
     @staticmethod
     def darkness():
+        logger.info("Creating darkness")
         return "darkness"
 
     @staticmethod
     def said(command):
+        logger.info("God said: %s", command)
         if command == "Let there be light":
+            logger.info(" -> resulted in light")
             return "light"
         if command == "Let there be a vault":
+            logger.info(" -> resulted in vault")
             return "vault"
         # TODO: handle more creation commands (e.g., "Let dry ground appear")
 
+        logger.warning("Unknown command: %s", command)
         return None
 
     @staticmethod
     def saw(thing):
+        logger.info("God saw %s", thing)
         return f"{thing} is good"
 
     @staticmethod
     def separate(light, darkness):
+        logger.info("Separating %s from %s", light, darkness)
         # TODO: implement logic for tracking separated elements
         return light, darkness
 
     @staticmethod
     def call(name, thing):
         """Associate a name with a thing, similar to God naming creations."""
+        logger.info("Calling %s %s", name, thing)
         return {name: thing}
-      
+
+
 class TheSpiritOfGod:
     # TODO: add more spiritual interactions
     @staticmethod
     def hover(target):
+        logger.info("Spirit hovering over %s", target)
         return f"hovering over {target}"


### PR DESCRIPTION
## Summary
- configure default logging in `bible.__init__`
- emit log messages from helper functions in `bible.actions`
- document log usage in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d2553b8c832f8867647418de9cbe