### PR TITLE
Add simple notes feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ ENV/
 
 # Misc
 .DS_Store
+webapp/notes.json

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you are interested in any aspect of this project, feel free to message me on 
    ```bash
    flask --app webapp run
    ```
+   Then open `http://localhost:5000/notes` to record notebook notes.
 
 The notebook imports helpers from the `bible` package to model passages programmatically.
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,4 +1,5 @@
 from webapp import create_app
+from webapp import notes as notes_module
 
 
 def test_index_route():
@@ -7,3 +8,15 @@ def test_index_route():
     response = client.get("/")
     assert response.status_code == 200
     assert b"Welcome to the Holy Bible App" in response.data
+
+
+def test_notes_route(tmp_path, monkeypatch):
+    notes_file = tmp_path / "notes.json"
+    monkeypatch.setattr(notes_module, "NOTES_FILE", notes_file)
+
+    app = create_app()
+    client = app.test_client()
+
+    response = client.post("/notes", data={"text": "My first note"}, follow_redirects=True)
+    assert response.status_code == 200
+    assert b"My first note" in response.data

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,5 +1,6 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, request, redirect, url_for
 from bible.actions import TheActionsOfGod
+from .notes import get_all_notes, save_note
 
 
 def create_app():
@@ -11,5 +12,16 @@ def create_app():
         # Using the actions module to demonstrate dynamic content
         verse = TheActionsOfGod.said("Let there be light")
         return render_template("index.html", verse=verse)
+
+    @app.route("/notes", methods=["GET", "POST"])
+    def notes():
+        if request.method == "POST":
+            text = request.form.get("text", "").strip()
+            if text:
+                save_note(text)
+            return redirect(url_for("notes"))
+
+        notes_list = get_all_notes()
+        return render_template("notes.html", notes=notes_list)
 
     return app

--- a/webapp/notes.py
+++ b/webapp/notes.py
@@ -1,0 +1,33 @@
+import json
+import os
+from pathlib import Path
+from typing import List, Dict
+
+
+NOTES_FILE = Path(
+    os.getenv("NOTES_FILE", Path(__file__).resolve().parent / "notes.json")
+)
+
+
+def load_notes() -> List[Dict[str, str]]:
+    """Load notes from the JSON file."""
+    if NOTES_FILE.exists():
+        with open(NOTES_FILE, "r", encoding="utf-8") as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return []
+    return []
+
+
+def save_note(text: str) -> None:
+    """Append a note to the JSON file."""
+    notes = load_notes()
+    note = {"id": len(notes) + 1, "text": text}
+    notes.append(note)
+    with open(NOTES_FILE, "w", encoding="utf-8") as f:
+        json.dump(notes, f, indent=2)
+
+
+def get_all_notes() -> List[Dict[str, str]]:
+    return load_notes()

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -7,5 +7,6 @@
   <body>
     <h1>Welcome to the Holy Bible App</h1>
     <p>{{ verse }} was spoken in Genesis.</p>
+    <p><a href="{{ url_for('notes') }}">Notebook Notes</a></p>
   </body>
 </html>

--- a/webapp/templates/notes.html
+++ b/webapp/templates/notes.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Notes</title>
+  </head>
+  <body>
+    <h1>Notebook Notes</h1>
+    <form method="post">
+      <textarea name="text" rows="4" cols="50" placeholder="Enter note"></textarea>
+      <br>
+      <button type="submit">Save Note</button>
+    </form>
+    <h2>Saved Notes</h2>
+    <ul>
+    {% for note in notes %}
+      <li>{{ note.text }}</li>
+    {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create a minimal note storage utility and template
- expose `/notes` route in the Flask app
- link the notes page from the index page
- document the new route in README
- ignore notes.json in git
- add tests for the notes feature

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d3d6a260832fa488faa20d1f93bd